### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ Purify support consistent color theme among terminals, editors and other things:
 - [x] [highlightjs](./highlightjs)
 - [x] [ncmpcpp](./ncmpcpp)
 
+### Fig
+
+Install `purify` with [Fig](https://fig.io) for zsh, fish, or bash in just one click. 
+
+<a href="https://fig.io/plugins/other/purify_kyoz" target="_blank"><img src="https://fig.io/badges/install-with-fig.svg" /></a>
+
+
 ## Todo
 
 I'll look into these terminals & editors when i have time. But mostly the time i'll use to maintain Vim and most used Terminal theme.


### PR DESCRIPTION
We recently listed `purify` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!